### PR TITLE
console.log in Node.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,9 +87,34 @@ module.exports = class BemEntityName {
 
         return this._type;
     }
-
-    toString() { return this.id;  }
-    valueOf()  { return this._obj; }
+    /**
+     * Returns string representing the entity name.
+     *
+     * @returns {string}
+     * @example
+     * const BemEntityName = require('bem-entity-name');
+     * const name = new BemEntityName({ block: 'button' });
+     *
+     * console.log(`name: ${name}`); // button
+     */
+    toString() { return this.id; }
+    /**
+     * Returns object representing the entity name. Is needed for debug in Node.js.
+     *
+     * In some browsers `console.log()` calls `valueOf()` on each argument.
+     * This method will be called to get custom string representation of the object.
+     *
+     * The representation object contains only `block`, `elem` and `mod` fields
+     * without private and deprecated fields (`modName` and `modVal`).
+     *
+     * @returns {object}
+     * @example
+     * const BemEntityName = require('bem-entity-name');
+     * const name = new BemEntityName({ block: 'button' });
+     *
+     * console.log(name); // { block: 'button' }
+     */
+    valueOf() { return this._obj; }
     /**
      * Returns object representing the entity name. Is needed for debug in Node.js.
      *

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const util = require('util');
+
 const naming = require('bem-naming');
 
 const stringifyEntity = naming.stringify;
@@ -88,7 +90,31 @@ module.exports = class BemEntityName {
 
     toString() { return this.id;  }
     valueOf()  { return this._obj; }
+    /**
+     * Returns object representing the entity name. Is needed for debug in Node.js.
+     *
+     * In Node.js, `console.log()` calls `util.inspect()` on each argument without a formatting placeholder.
+     * This method will be called to get custom string representation of the object.
+     *
+     * The representation object contains only `block`, `elem` and `mod` fields
+     * without private and deprecated fields (`modName` and `modVal`).
+     *
+     * @param {integer} depth — tells inspect how many times to recurse while formatting the object.
+     * @param {object} options — An optional `options` object may be passed
+     *                         	 that alters certain aspects of the formatted string.
+     *
+     * @returns {object}
+     * @example
+     * const BemEntityName = require('bem-entity-name');
+     * const name = new BemEntityName({ block: 'button' });
+     *
+     * console.log(name); // { block: 'button' }
+     */
+    inspect(depth, options) {
+        const stringRepresentation = util.inspect(this._obj, options);
 
+        return `BemEntityName ${stringRepresentation}`;
+    }
     /**
      * Determines whether specified entity is the deepEqual entity.
      *

--- a/test/fields.test.js
+++ b/test/fields.test.js
@@ -1,6 +1,6 @@
-import test from 'ava';
+const test = require('ava');
 
-import BemEntityName from '../index';
+const BemEntityName = require('../index');
 
 test('should provide `block` field', t => {
     const entity = new BemEntityName({ block: 'block' });

--- a/test/id.test.js
+++ b/test/id.test.js
@@ -1,8 +1,8 @@
-import test from 'ava';
-import sinon from 'sinon';
-import proxyquire from 'proxyquire';
+const test = require('ava');
+const sinon = require('sinon');
+const proxyquire = require('proxyquire');
 
-import BemEntityName from '../index';
+const BemEntityName = require('../index');
 
 test('should build equal id for equal blocks', t => {
     const entity1 = new BemEntityName({ block: 'block' });

--- a/test/inspect.js
+++ b/test/inspect.js
@@ -1,0 +1,25 @@
+const test = require('ava');
+const sinon = require('sinon');
+
+const BemEntityName = require('../index');
+
+const EOL = require('os').EOL;
+
+test.beforeEach(t => {
+    t.context.stdoutWriteStub = sinon.stub(process.stdout, 'write');
+});
+
+test.afterEach(t => {
+    t.context.stdoutWriteStub.restore();
+});
+
+test('should return entity object', t => {
+    const obj = { block: 'block' };
+    const entity = new BemEntityName(obj);
+
+    console.log(entity);
+
+    const message = `BemEntityName { block: 'block' }${EOL}`;
+
+    t.true(t.context.stdoutWriteStub.calledWith(message));
+});

--- a/test/is-equal.test.js
+++ b/test/is-equal.test.js
@@ -1,6 +1,6 @@
-import test from 'ava';
+const test = require('ava');
 
-import BemEntityName from '../index';
+const BemEntityName = require('../index');
 
 test('should detect equal block', t => {
     const entity1 = new BemEntityName({ block: 'block' });

--- a/test/normalize.test.js
+++ b/test/normalize.test.js
@@ -1,6 +1,6 @@
-import test from 'ava';
+const test = require('ava');
 
-import BemEntityName from '../index';
+const BemEntityName = require('../index');
 
 test('should normalize boolean modifier', t => {
     const entity = new BemEntityName({ block: 'block', mod: { name: 'mod' } });

--- a/test/throws.test.js
+++ b/test/throws.test.js
@@ -1,6 +1,6 @@
-import test from 'ava';
+const test = require('ava');
 
-import BemEntityName from '../index';
+const BemEntityName = require('../index');
 
 test('should throw error for if entity object is not valid', t => {
     t.throws(

--- a/test/to-string.test.js
+++ b/test/to-string.test.js
@@ -1,6 +1,6 @@
-import test from 'ava';
-import sinon from 'sinon';
-import proxyquire from 'proxyquire';
+const test = require('ava');
+const sinon = require('sinon');
+const proxyquire = require('proxyquire');
 
 const spy = sinon.spy();
 const BemEntityName = proxyquire('../index', {

--- a/test/type.test.js
+++ b/test/type.test.js
@@ -1,6 +1,6 @@
-import test from 'ava';
-import sinon from 'sinon';
-import proxyquire from 'proxyquire';
+const test = require('ava');
+const sinon = require('sinon');
+const proxyquire = require('proxyquire');
 
 test.beforeEach('setup', t => {
     t.context.stub = sinon.stub().returns('type');

--- a/test/value-of.test.js
+++ b/test/value-of.test.js
@@ -1,6 +1,6 @@
-import test from 'ava';
+const test = require('ava');
 
-import BemEntityName from '../index';
+const BemEntityName = require('../index');
 
 test('should return entity object', t => {
     const obj = { block: 'block' };


### PR DESCRIPTION
In Node.js `console.log` doesn't use `valueOf()` method to build string representation of the object.

In Node.js, `console.log()` calls `util.inspect()` on each argument without a formatting placeholder.

Example:

```js
const BemEntityName = require('bem-entity-name');
const name = new BemEntityName({ block: 'button' });

console.log(name);
```

Before fix:

```js
// BemEntityName { _obj: { block: 'button' } }
```

After fix:

```js
// BemEntityName { block: 'button' }
```