### PR TITLE
Backward Compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,6 +52,24 @@ module.exports = class BemEntityName {
      */
     get mod() { return this._obj.mod || {}; }
     /**
+     * Returns the name of modifier of this entity.
+     *
+     * If entity is not modifier then returns `undefined`.
+     *
+     * @returns {string} entity modifier name.
+     * @deprecated use `mod.name` instead.
+     */
+    get modName() { return this.mod.name; }
+    /**
+     * Returns the value of modifier of this entity.
+     *
+     * If entity is not modifier then returns `undefined`.
+     *
+     * @returns {string} entity modifier name.
+     * @deprecated use `mod.val` instead.
+     */
+    get modVal() { return this.mod.val; }
+    /**
      * Returns id for this entity.
      *
      * @returns {string} id of entity.

--- a/test/fields.test.js
+++ b/test/fields.test.js
@@ -31,3 +31,27 @@ test('should provide `modVal` field', t => {
 
     t.is(entity.modVal, 'val');
 });
+
+test('should return `undefined` if entity is not element', t => {
+    const entity = new BemEntityName({ block: 'block' });
+
+    t.is(entity.elem, undefined);
+});
+
+test('should return empty object if entity is not modifier', t => {
+    const entity = new BemEntityName({ block: 'block' });
+
+    t.deepEqual(entity.mod, {});
+});
+
+test('should return `undefined` in `modName` property if entity is not modifier', t => {
+    const entity = new BemEntityName({ block: 'block' });
+
+    t.is(entity.modName, undefined);
+});
+
+test('should return `undefined` in `modVal` property if entity is not modifier', t => {
+    const entity = new BemEntityName({ block: 'block' });
+
+    t.is(entity.modVal, undefined);
+});

--- a/test/fields.test.js
+++ b/test/fields.test.js
@@ -19,3 +19,15 @@ test('should provide `mod` field', t => {
 
     t.deepEqual(entity.mod, { name: 'mod', val: 'val' });
 });
+
+test('should provide `modName` field', t => {
+    const entity = new BemEntityName({ block: 'block', mod: { name: 'mod', val: 'val' } });
+
+    t.is(entity.modName, 'mod');
+});
+
+test('should provide `modVal` field', t => {
+    const entity = new BemEntityName({ block: 'block', mod: { name: 'mod', val: 'val' } });
+
+    t.is(entity.modVal, 'val');
+});


### PR DESCRIPTION
Resolved #39.

It's need to use `BemEntityName` in bem-naming with backward
compatibility (https://github.com/bem-sdk/bem-naming/issues/126).

But this fields will not be visible in representation of the object.

```js
const BemEntityName = require('bem-entity-name');

const name = new BemEntityName({ block: 'button', mod: 'disabled' });

name.modName; // disabled
name.modVal; // true

console.log(name); // BemEntityName { block: 'button', mod: { name:
'disabled', val: true } }
```